### PR TITLE
🐛 Fix plugins config

### DIFF
--- a/preset.json
+++ b/preset.json
@@ -2,24 +2,6 @@
 	"bare": true,
 	"useConfigFiles": true,
 	"plugins": {
-		"@vue/cli-plugin-babel": {},
-		"@vue/cli-plugin-typescript": {
-			"lintOn": [
-				"save",
-				"commit"
-			],
-			"useTsWithBabel": true,
-			"convertJsToTs": false
-		},
-		"@vue/cli-plugin-eslint": {
-			"config": "standard",
-			"lintOn": ["save"]
-		},
-		"@vue/cli-plugin-router": {
-			"historyMode": true
-		},
-		"@vue/cli-plugin-vuex": {},
-		"@vue/cli-plugin-unit-jest": {},
 		"@cnamts/vue-cli-plugin-vue-dash": {
 			"version": "next",
 			"prompts": true


### PR DESCRIPTION
Correction de la configuration des plugins.

Sur certains postes les fichiers `Home.vue`, `tsconfig.json` et `tests/unit/index.ts` ne sont pas copiés correctement de notre plugin et reste comme définis dans le template par défaut, générant des erreurs lors du lancement du projet ainsi qu'une baisse de la qualité de l'expérience développeur, les fichiers devant être corrigés manuellement.

[Une issue](https://github.com/vuejs/vue-cli/issues/6334) a été ouverte sur Vue CLI, ce comportement n'étant pas totalement consistant, il s'agit bien d'un bug.

Notre template contient le template projet en entier, incluant la configuration de TypeScript, du routeur, de Vuex etc.
Importer les plugins Vue CLI dans le template fait doublon avec le contenu de notre projet, en supprimant l'import (et donc l'invocation) de ceux-ci il n'y a plus de bug de génération.

⚠️ À ne merger qu'au moment de la release du plugin Vue Dash